### PR TITLE
Estimate count query for admin logs

### DIFF
--- a/SS14.Admin/Helpers/PaginatedList.cs
+++ b/SS14.Admin/Helpers/PaginatedList.cs
@@ -15,7 +15,7 @@ namespace SS14.Admin.Helpers
         bool HasNextPage { get; }
         bool HasPrevPage { get; }
     }
-    
+
     public sealed class PaginatedList<T> : IPaginatedList
     {
         public T[] PaginatedItems { get; }
@@ -28,13 +28,13 @@ namespace SS14.Admin.Helpers
         {
             PaginatedItems = Array.Empty<T>();
         }
-        
+
         public PaginatedList(T[] paginatedItems, int totalCount, int pageIndex, int pageSize)
         {
             PageIndex = pageIndex;
             PageSize = pageSize;
             PageCount = (int) Math.Ceiling(totalCount / (double) pageSize);
-            
+
             PaginatedItems = paginatedItems;
             TotalCount = totalCount;
         }
@@ -42,17 +42,17 @@ namespace SS14.Admin.Helpers
         public bool HasNextPage => PageIndex < PageCount - 1;
         public bool HasPrevPage => PageIndex > 0;
 
-        public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> query, int pageIndex, int pageSize)
+        public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> query, int pageIndex, int pageSize, int? count = null)
         {
-            return await CreateLinqAsync(query, e => e, pageIndex, pageSize);
+            return await CreateLinqAsync(query, e => e, pageIndex, pageSize, count);
         }
-        
+
         public static async Task<PaginatedList<T>> CreateLinqAsync<TQuery>(
-            IQueryable<TQuery> query, 
-            Func<IEnumerable<TQuery>, IEnumerable<T>> convert, 
-            int pageIndex, int pageSize)
+            IQueryable<TQuery> query,
+            Func<IEnumerable<TQuery>, IEnumerable<T>> convert,
+            int pageIndex, int pageSize, int? optCount = null)
         {
-            var count = await query.CountAsync();
+            var count = optCount ?? await query.CountAsync();
             var items = await query
                 .Skip(pageIndex * pageSize)
                 .Take(pageSize)

--- a/SS14.Admin/Helpers/PaginatedList.cs
+++ b/SS14.Admin/Helpers/PaginatedList.cs
@@ -39,7 +39,7 @@ namespace SS14.Admin.Helpers
             TotalCount = totalCount;
         }
 
-        public bool HasNextPage => PageIndex < PageCount - 1;
+        public bool HasNextPage => PaginatedItems.Length >= PageSize;
         public bool HasPrevPage => PageIndex > 0;
 
         public static async Task<PaginatedList<T>> CreateAsync(IQueryable<T> query, int pageIndex, int pageSize, int? count = null)

--- a/SS14.Admin/Helpers/PaginationState.cs
+++ b/SS14.Admin/Helpers/PaginationState.cs
@@ -49,9 +49,9 @@ namespace SS14.Admin.Helpers
                 AllRouteData.Add("perPage", PerPage.ToString(CultureInfo.InvariantCulture));
         }
 
-        public async Task LoadAsync(IQueryable<T> query)
+        public async Task LoadAsync(IQueryable<T> query, int? count = null)
         {
-            List = await PaginatedList<T>.CreateAsync(query, PageIndex, PerPage);
+            List = await PaginatedList<T>.CreateAsync(query, PageIndex, PerPage, count);
         }
 
         public async Task LoadLinqAsync<TQuery>(

--- a/SS14.Admin/Pages/Logs/Index.cshtml.cs
+++ b/SS14.Admin/Pages/Logs/Index.cshtml.cs
@@ -45,7 +45,7 @@ namespace SS14.Admin.Pages.Logs
             SortState.Init(sort, AllRouteData);
 
             Pagination.Init(pageIndex, perPage, AllRouteData);
-            
+
             IQueryable<AdminLog> logQuery = _dbContext.AdminLog
                 .Include(log => log.Round)
                 .ThenInclude(round => round.Server);
@@ -61,7 +61,7 @@ namespace SS14.Admin.Pages.Logs
 
             logQuery = SortState.ApplyToQuery(logQuery);
             Console.WriteLine(logQuery.ToQueryString());
-            await Pagination.LoadAsync(logQuery);
+            await Pagination.LoadAsync(logQuery, _dbContext.CountAdminLogs());
         }
 
         private static IQueryable<AdminLog> ApplyDateFilter(IQueryable<AdminLog> query, DateTime date, bool isEndDate = false)


### PR DESCRIPTION
Adds an optional count parameter to pagination helpers for circumventing an expensive count query.
It's used for the admin log table.

Requires space-wizards/space-station-14#7956