### PR TITLE
Bans and Role bans now appear on the player info screen

### DIFF
--- a/SS14.Admin/Pages/Bans/Index.cshtml
+++ b/SS14.Admin/Pages/Bans/Index.cshtml
@@ -64,4 +64,4 @@
     </div>
 </form>
 
-<partial name="Tables/BansTable" model="@(new BansTableModel(Model.SortState, Model.Pagination, highlightBan))"/>
+<partial name="Tables/BansTable" model="@(new BansTableModel(Model.SortState, Model.Pagination, highlightBan,true))"/>

--- a/SS14.Admin/Pages/Connections/Hits.cshtml
+++ b/SS14.Admin/Pages/Connections/Hits.cshtml
@@ -38,4 +38,4 @@
     </div>
 </form>
 
-<partial name="Tables/BansTable" model="@(new BansTableModel(Model.SortState, Model.Pagination, null))"/>
+<partial name="Tables/BansTable" model="@(new BansTableModel(Model.SortState, Model.Pagination, null, true))"/>

--- a/SS14.Admin/Pages/Players/Info.cshtml
+++ b/SS14.Admin/Pages/Players/Info.cshtml
@@ -1,6 +1,7 @@
 ﻿@page "{userId}"
 @using Content.Server.Database
 @using SS14.Admin.Helpers
+@using SS14.Admin.Pages.Tables
 @model SS14.Admin.Pages.Players.Info
 
 @{
@@ -113,4 +114,14 @@
         }
         </tbody>
     </table>
+</div>
+
+<div class="container">
+    <h2>Bans</h2>
+    <partial name="Tables/BansTable" model="@(new BansTableModel(Model.GameSortState,Model.GameBanPagination, 0 ,false))"/>
+</div>
+
+<div class="container">
+    <h2>Role Bans</h2>
+    <partial name="Tables/RoleBansTable" model="@(new RoleBansTableModel(Model.RoleSortState,Model.RoleBanPagination, 0, false))"/>
 </div>

--- a/SS14.Admin/Pages/Players/Info.cshtml.cs
+++ b/SS14.Admin/Pages/Players/Info.cshtml.cs
@@ -2,26 +2,61 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using SS14.Admin.Helpers;
+using static SS14.Admin.Pages.BansModel;
+using static SS14.Admin.Pages.RoleBans.Index;
 
 namespace SS14.Admin.Pages.Players;
 
 public sealed class Info : PageModel
 {
     private readonly PostgresServerDbContext _dbContext;
+    private readonly BanHelper _banHelper;
 
     public Player Player { get; set; } = default!;
-
     public AdminNote[] Notes { get; set; } = default!;
     public PlayTime[] PlayTimes { get; set; } = default!;
     public Profile[] Profiles { get; set; } = default!;
-
-    public Info(PostgresServerDbContext dbContext)
+    public ISortState RoleSortState { get; private set; } = default!;
+    public ISortState GameSortState { get; private set; } = default!;
+    public PaginationState<Ban> GameBanPagination { get; } = new(100);
+    public PaginationState<RoleBan> RoleBanPagination { get; } = new(100);
+    public Dictionary<string, string?> GameBanRouteData { get; } = new();
+    public Dictionary<string, string?> RoleBanRouteData { get; } = new();
+    public Info(PostgresServerDbContext dbContext, BanHelper banHelper)
     {
         _dbContext = dbContext;
+        _banHelper = banHelper;
     }
 
-    public async Task<IActionResult> OnGetAsync(Guid userId)
+    public async Task<IActionResult> OnGetAsync(
+        Guid userId,
+        int? pageIndex,
+        int? perPage,
+        string? sort)
     {
+        GameBanPagination.Init(pageIndex, perPage, GameBanRouteData);
+        RoleBanPagination.Init(pageIndex, perPage, RoleBanRouteData);
+
+        var gameBans = SearchHelper.SearchServerBans(_banHelper.CreateServerBanJoin(), userId.ToString());
+        var roleBans = SearchHelper.SearchRoleBans(_banHelper.CreateRoleBanJoin(), userId.ToString());
+
+        GameBanRouteData.Add("search", userId.ToString());
+        GameBanRouteData.Add("show", "all");
+        RoleBanRouteData.Add("search", userId.ToString());
+        RoleBanRouteData.Add("show", "all");
+
+        if (sort == "role")
+        {
+            GameSortState = await LoadSortBanTableData(GameBanPagination, gameBans, default, GameBanRouteData);
+            RoleSortState = await LoadSortBanTableData(RoleBanPagination, roleBans, sort, RoleBanRouteData);
+        }
+        else
+        {
+            GameSortState = await LoadSortBanTableData(GameBanPagination, gameBans, sort, GameBanRouteData);
+            RoleSortState = await LoadSortBanTableData(RoleBanPagination, roleBans, sort, RoleBanRouteData);
+        }
+
         var player = await _dbContext.Player.SingleOrDefaultAsync(a => a.UserId == userId);
         if (player == null)
             return NotFound();

--- a/SS14.Admin/Pages/RoleBans/Index.cshtml
+++ b/SS14.Admin/Pages/RoleBans/Index.cshtml
@@ -64,4 +64,4 @@
     </div>
 </form>
 
-<partial name="Tables/RoleBansTable" model="@(new RoleBansTableModel(Model.SortState, Model.Pagination, highlightBan))"/>
+<partial name="Tables/RoleBansTable" model="@(new RoleBansTableModel(Model.SortState, Model.Pagination, highlightBan, true))"/>

--- a/SS14.Admin/Pages/Tables/BansTable.cshtml
+++ b/SS14.Admin/Pages/Tables/BansTable.cshtml
@@ -1,9 +1,13 @@
 ﻿@model SS14.Admin.Pages.Tables.BansTableModel
 
-
-<partial name="Tables/Pagination" for="Pagination"/>
-
-<table class="table table-striped mt-3">
+@{
+    var b = Model.PaginationState;
+    if (b == true)
+    {
+        <partial name="Tables/Pagination" for="Pagination"/>
+    }
+}
+    <table class="table table-striped mt-3">
     <thead>
     <tr>
         <th style="min-width: 210px">
@@ -111,4 +115,7 @@
     </tbody>
 </table>
 
+@if (b == true)
+{
 <partial name="Tables/Pagination" for="Pagination"/>
+}

--- a/SS14.Admin/Pages/Tables/BansTable.cshtml.cs
+++ b/SS14.Admin/Pages/Tables/BansTable.cshtml.cs
@@ -2,4 +2,4 @@
 
 namespace SS14.Admin.Pages.Tables;
 
-public sealed record BansTableModel(ISortState SortState, PaginationState<BansModel.Ban> Pagination, int? HighlightBan);
+public sealed record BansTableModel(ISortState SortState, PaginationState<BansModel.Ban> Pagination, int? HighlightBan, bool PaginationState);

--- a/SS14.Admin/Pages/Tables/RoleBansTable.cshtml
+++ b/SS14.Admin/Pages/Tables/RoleBansTable.cshtml
@@ -1,7 +1,12 @@
 ﻿@model SS14.Admin.Pages.Tables.RoleBansTableModel
 
-
-<partial name="Tables/Pagination" for="Pagination"/>
+@{
+    var b = Model.PaginationState;
+    if (b == true)
+    {
+        <partial name="Tables/Pagination" for="Pagination"/>
+    }
+}
 
 <table class="table table-striped mt-3">
     <thead>
@@ -101,4 +106,7 @@
     </tbody>
 </table>
 
-<partial name="Tables/Pagination" for="Pagination"/>
+@if(b == true)
+{
+    <partial name="Tables/Pagination" for="Pagination"/>
+}

--- a/SS14.Admin/Pages/Tables/RoleBansTable.cshtml.cs
+++ b/SS14.Admin/Pages/Tables/RoleBansTable.cshtml.cs
@@ -6,4 +6,5 @@ namespace SS14.Admin.Pages.Tables;
 public sealed record RoleBansTableModel(
     ISortState SortState,
     PaginationState<Index.RoleBan> Pagination,
-    int? HighlightBan);
+    int? HighlightBan,
+    bool PaginationState);


### PR DESCRIPTION
Closes #19 

Adds game bans and role bans to the Player info page see attached images


<details>
<summary>Image of New Full Page</summary>

 ![NewPlayerPage](https://github.com/space-wizards/SS14.Admin/assets/66805063/1c728655-5118-43f7-bb97-b4f73271b067)

</details>
<details>
<summary>Image of Game Bans</summary>

![Bans](https://github.com/space-wizards/SS14.Admin/assets/66805063/541f43fe-65bc-44ef-bd07-810860d33ff0)

</details><details>
<summary>Image of Role Bans</summary>

![RoleBans](https://github.com/space-wizards/SS14.Admin/assets/66805063/b81bd7c4-51b2-4d32-9eb8-fdd9dd8daf4e)

</details>