### PR TITLE
Hide PII from admins who lack that permission

### DIFF
--- a/SS14.Admin/Admins/AdminFlags.cs
+++ b/SS14.Admin/Admins/AdminFlags.cs
@@ -25,6 +25,7 @@
 
         /// <summary>
         ///     !!FUN!!
+        ///     This is stuff that trial administrators shouldn't quite have access to yet, e.g. for running events.
         /// </summary>
         Fun = 1 << 3,
 
@@ -57,6 +58,71 @@
         ///     Makes you british.
         /// </summary>
         //Piss = 1 << 9,
+
+        /// <summary>
+        ///     Lets you view admin logs.
+        /// </summary>
+        Logs = 1 << 9,
+
+        /// <summary>
+        ///     Lets you modify the round (forcemap, loadgamemap, etc)
+        /// </summary>
+        Round = 1 << 10,
+
+        /// <summary>
+        ///     Lets you use BQL queries.
+        /// </summary>
+        Query = 1 << 11,
+
+        /// <summary>
+        ///     Lets you use the admin help system.
+        /// </summary>
+        Adminhelp = 1 << 12,
+
+        /// <summary>
+        ///     Lets you view admin notes.
+        /// </summary>
+        ViewNotes = 1 << 13,
+
+        /// <summary>
+        ///     Lets you create, edit and delete admin notes.
+        /// </summary>
+        EditNotes = 1 << 14,
+
+        /// <summary>
+        ///     Lets you Massban, on SS14.Admin
+        /// </summary>
+        MassBan = 1 << 15,
+
+        /// <summary>
+        /// Allows you to remain hidden from adminwho except to other admins with this flag.
+        /// </summary>
+        Stealth = 1 << 16,
+
+        ///<summary>
+		/// Allows you to use Admin chat
+		///</summary>
+		Adminchat = 1 << 17,
+
+        ///<summary>
+        /// Permits the visibility of Pii in game and on SS14 Admin
+        ///</summary>
+        Pii = 1 << 18,
+
+        /// <summary>
+        ///     Lets you take moderator actions on the game server.
+        /// </summary>
+        Moderator = 1 << 19,
+
+        /// <summary>
+        ///     Lets you check currently online admins.
+        /// </summary>
+        AdminWho = 1 << 20,
+
+        /// <summary>
+        ///     Lets you set the color of your OOC name.
+        /// </summary>
+        NameColor = 1 << 21,
 
         /// <summary>
         ///     Dangerous host permissions like scsi.

--- a/SS14.Admin/Constants.cs
+++ b/SS14.Admin/Constants.cs
@@ -3,4 +3,6 @@
 public static class Constants
 {
     public const int HwidLength = 32;
+
+    public const string PIIRole = "PII";
 }

--- a/SS14.Admin/Pages/Bans/Create.cshtml
+++ b/SS14.Admin/Pages/Bans/Create.cshtml
@@ -17,21 +17,28 @@
     <div class="form-group row">
         <label asp-for="Input.IP" class="col-sm-3 col-form-label">IP address/CIDR</label>
         <div class="col-sm-9">
-            <input asp-for="Input.IP" value="@Model.Input.IP" class="form-control">
+            <div class="row">
+                <div class="col-sm">
+                    <input asp-for="Input.IP" value="@Model.Input.IP" class="form-control">
+                </div>
+                <div class="col-sm-auto align-items-center d-flex">
+                    <input asp-for="Input.UseLatestIp" class="form-check-input" style="margin-right: 5px;">
+                    <label class="form-check-label">Use latest</label>
+                </div>
+            </div>
         </div>
     </div>
     <div class="form-group row">
         <label asp-for="Input.HWid" class="col-sm-3 col-form-label">HWID</label>
         <div class="col-sm-9">
-            <input asp-for="Input.HWid" value="@Model.Input.HWid" class="form-control">
-        </div>
-    </div>
-    <div class="form-group row">
-        <div class="col-sm-3"><!-- Empty on purpose --></div>
-        <div class="col-sm-9">
-            <div class="form-check">
-                <input asp-for="Input.UseLatest" class="form-check-input">
-                <label class="form-check-label">Use details from latest connection</label>
+            <div class="row">
+                <div class="col-sm">
+                    <input asp-for="Input.HWid" value="@Model.Input.HWid" class="form-control">
+                </div>
+                <div class="col-sm-auto align-items-center d-flex">
+                    <input asp-for="Input.UseLatestHwid" class="form-check-input" style="margin-right: 5px;">
+                    <label class="form-check-label">Use latest</label>
+                </div>
             </div>
         </div>
     </div>

--- a/SS14.Admin/Pages/Bans/Create.cshtml
+++ b/SS14.Admin/Pages/Bans/Create.cshtml
@@ -17,26 +17,21 @@
     <div class="form-group row">
         <label asp-for="Input.IP" class="col-sm-3 col-form-label">IP address/CIDR</label>
         <div class="col-sm-9">
-            <div class="row">
-                <div class="col-sm">
-                    <input asp-for="Input.IP" value="@Model.Input.IP" class="form-control">
-                </div>
-                <div class="col-sm-auto">
-                    <input asp-page-handler="Fill" type="submit" value="Find last Info" class="btn btn-secondary btn-block">
-                </div>
-            </div>
+            <input asp-for="Input.IP" value="@Model.Input.IP" class="form-control">
         </div>
     </div>
     <div class="form-group row">
         <label asp-for="Input.HWid" class="col-sm-3 col-form-label">HWID</label>
         <div class="col-sm-9">
-            <div class="row">
-                <div class="col-sm">
-                    <input asp-for="Input.HWid" value="@Model.Input.HWid" class="form-control">
-                </div>
-                <div class="col-sm-auto">
-                    <input asp-page-handler="Fill" type="submit" value="Find last Info" class="btn btn-secondary btn-block">
-                </div>
+            <input asp-for="Input.HWid" value="@Model.Input.HWid" class="form-control">
+        </div>
+    </div>
+    <div class="form-group row">
+        <div class="col-sm-3"><!-- Empty on purpose --></div>
+        <div class="col-sm-9">
+            <div class="form-check">
+                <input asp-for="Input.UseLatest" class="form-check-input">
+                <label class="form-check-label">Use details from latest connection</label>
             </div>
         </div>
     </div>

--- a/SS14.Admin/Pages/Bans/Create.cshtml.cs
+++ b/SS14.Admin/Pages/Bans/Create.cshtml.cs
@@ -33,6 +33,12 @@ namespace SS14.Admin.Pages.Bans
 
         public async Task OnPostFillAsync()
         {
+            if (!User.IsInRole(Constants.PIIRole))
+            {
+                TempData.SetStatusError("You cannot do that.");
+                return;
+            }
+
             if (string.IsNullOrWhiteSpace(Input.NameOrUid))
             {
                 TempData.SetStatusError("Must provide name/UID.");

--- a/SS14.Admin/Pages/Bans/Create.cshtml.cs
+++ b/SS14.Admin/Pages/Bans/Create.cshtml.cs
@@ -27,7 +27,8 @@ namespace SS14.Admin.Pages.Bans
             public string? NameOrUid { get; set; }
             public string? IP { get; set; }
             public string? HWid { get; set; }
-            public bool UseLatest { get; set; }
+            public bool UseLatestIp {get; set; }
+            public bool UseLatestHwid { get; set; }
             public int LengthMinutes { get; set; }
             [Required] public string Reason { get; set; } = "";
         }
@@ -39,7 +40,7 @@ namespace SS14.Admin.Pages.Bans
             var ipAddr = Input.IP;
             var hwid = Input.HWid;
 
-            if (Input.UseLatest)
+            if (Input.UseLatestHwid || Input.UseLatestIp)
             {
                 if (string.IsNullOrWhiteSpace(Input.NameOrUid))
                 {
@@ -54,8 +55,8 @@ namespace SS14.Admin.Pages.Bans
                     return Page();
                 }
 
-                ipAddr = lastInfo.Value.address.ToString();
-                hwid = lastInfo.Value.hwid is { } h ? Convert.ToBase64String(h) : null;
+                ipAddr = Input.UseLatestIp ? lastInfo.Value.address.ToString() : Input.IP;
+                hwid = Input.UseLatestHwid ? (lastInfo.Value.hwid is { } h ? Convert.ToBase64String(h) : null) : Input.HWid;
             }
 
             var error = await _banHelper.FillBanCommon(

--- a/SS14.Admin/Pages/Bans/Hits.cshtml.cs
+++ b/SS14.Admin/Pages/Bans/Hits.cshtml.cs
@@ -53,7 +53,7 @@ public class Hits : PageModel
             .Where(bh => bh.BanId == banEntry.Ban.Id)
             .Select(bh => bh.Connection);
 
-        logQuery = SearchHelper.SearchConnectionLog(logQuery, search);
+        logQuery = SearchHelper.SearchConnectionLog(logQuery, search, User);
 
         SortState = await ConnectionsIndexModel.LoadSortConnectionsTableData(
             Pagination,

--- a/SS14.Admin/Pages/Bans/Index.cshtml.cs
+++ b/SS14.Admin/Pages/Bans/Index.cshtml.cs
@@ -35,7 +35,7 @@ namespace SS14.Admin.Pages
         {
             Pagination.Init(pageIndex, perPage, AllRouteData);
 
-            var bans = SearchHelper.SearchServerBans(_banHelper.CreateServerBanJoin(), search);
+            var bans = SearchHelper.SearchServerBans(_banHelper.CreateServerBanJoin(), search, User);
 
             bans = show switch
             {

--- a/SS14.Admin/Pages/Connections/Hits.cshtml
+++ b/SS14.Admin/Pages/Connections/Hits.cshtml
@@ -15,7 +15,7 @@
         <dd class="col-sm-10">@Model.Log.UserName</dd>
         <dt class="col-sm-2">User ID:</dt>
         <dd class="col-sm-10 font-monospace">@Model.Log.UserId</dd>
-        @if (User.IsInRole("ADMIN"))
+        @if (User.IsInRole(Constants.PIIRole))
         {
             <dt class="col-sm-2">IP:</dt>
             <dd class="col-sm-10 font-monospace">@Model.Log.Address</dd>

--- a/SS14.Admin/Pages/Connections/Hits.cshtml.cs
+++ b/SS14.Admin/Pages/Connections/Hits.cshtml.cs
@@ -47,7 +47,7 @@ public sealed class Hits : PageModel
 
         Pagination.Init(pageIndex, perPage, AllRouteData);
 
-        var banQuery = SearchHelper.SearchServerBans(_banHelper.CreateServerBanJoin(), search)
+        var banQuery = SearchHelper.SearchServerBans(_banHelper.CreateServerBanJoin(), search, User)
             .Join(_dbContext.ServerBanHit, bj => bj.Ban.Id, bh => bh.BanId, (join, hit) => new
             {
                 join, hit

--- a/SS14.Admin/Pages/Connections/Index.cshtml.cs
+++ b/SS14.Admin/Pages/Connections/Index.cshtml.cs
@@ -72,7 +72,7 @@ namespace SS14.Admin.Pages.Connections
             AllRouteData.Add("showSet", "true");
 
             IQueryable<ConnectionLog> logQuery = _dbContext.ConnectionLog;
-            logQuery = SearchHelper.SearchConnectionLog(logQuery, search);
+            logQuery = SearchHelper.SearchConnectionLog(logQuery, search, User);
 
             var acceptableDenies = new List<ConnectionDenyReason?>();
             if (showAccepted)

--- a/SS14.Admin/Pages/Players/Index.cshtml
+++ b/SS14.Admin/Pages/Players/Index.cshtml
@@ -43,8 +43,16 @@
             </td>
             <td class="font-monospace small">@player.UserId</td>
             <td>@player.LastSeenTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
-            <td class="font-monospace constrained-150">@player.LastSeenAddress</td>
-            <td class="font-monospace constrained-150">@BanHelper.FormatHwid(player.LastSeenHWId)</td>
+            @if (User.IsInRole(Constants.PIIRole))
+            {
+                <td class="font-monospace constrained-150">@player.LastSeenAddress</td>
+                <td class="font-monospace constrained-150">@BanHelper.FormatHwid(player.LastSeenHWId)</td>
+            }
+            else
+            {
+                <td class="font-monospace constrained-150">Hidden</td>
+                <td class="font-monospace constrained-150">Hidden</td>
+            }
             <td>@player.FirstSeenTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
             <td>
                 <a asp-page="/Players/Info" asp-route-userId="@player.UserId" class="btn btn-secondary">Player Info</a>

--- a/SS14.Admin/Pages/Players/Index.cshtml.cs
+++ b/SS14.Admin/Pages/Players/Index.cshtml.cs
@@ -40,7 +40,7 @@ namespace SS14.Admin.Pages.Players
             AllRouteData.Add("search", CurrentFilter);
 
             IQueryable<Player> userQuery = _dbContext.Player;
-            userQuery = SearchHelper.SearchPlayers(userQuery, search);
+            userQuery = SearchHelper.SearchPlayers(userQuery, search, User);
 
             userQuery = SortState.ApplyToQuery(userQuery);
 

--- a/SS14.Admin/Pages/Players/Info.cshtml
+++ b/SS14.Admin/Pages/Players/Info.cshtml
@@ -22,18 +22,21 @@
         <dd class="col-sm-10">@Model.Player.FirstSeenTime.ToString("yyyy-MM-dd HH:mm:ss")</dd>
         <dt class="col-sm-2">Last seen time:</dt>
         <dd class="col-sm-10">@Model.Player.LastSeenTime.ToString("yyyy-MM-dd HH:mm:ss")</dd>
-        <dt class="col-sm-2">Last seen address:</dt>
-        <dd class="col-sm-10 font-monospace">
-            <a asp-page="../Connections/Index" asp-route-search="@Model.Player.LastSeenAddress">
-                @Model.Player.LastSeenAddress
-            </a>
-        </dd>
-        <dt class="col-sm-2">Last seen HWID:</dt>
-        <dd class="col-sm-10 font-monospace">
-            <a asp-page="../Connections/Index" asp-route-search="@BanHelper.FormatHwid(Model.Player.LastSeenHWId)">
-                @BanHelper.FormatHwid(Model.Player.LastSeenHWId)
-            </a>
-        </dd>
+        @if (User.IsInRole(Constants.PIIRole))
+        {
+            <dt class="col-sm-2">Last seen address:</dt>
+            <dd class="col-sm-10 font-monospace">
+                <a asp-page="../Connections/Index" asp-route-search="@Model.Player.LastSeenAddress">
+                    @Model.Player.LastSeenAddress
+                </a>
+            </dd>
+            <dt class="col-sm-2">Last seen HWID:</dt>
+            <dd class="col-sm-10 font-monospace">
+                <a asp-page="../Connections/Index" asp-route-search="@BanHelper.FormatHwid(Model.Player.LastSeenHWId)">
+                    @BanHelper.FormatHwid(Model.Player.LastSeenHWId)
+                </a>
+            </dd>
+        }
         <dt class="col-sm-2">Whitelisted:</dt>
         <dd class="col-sm-10 font-monospace">
             @if (Model.Whitelisted)

--- a/SS14.Admin/Pages/Players/Info.cshtml.cs
+++ b/SS14.Admin/Pages/Players/Info.cshtml.cs
@@ -39,8 +39,8 @@ public sealed class Info : PageModel
         GameBanPagination.Init(pageIndex, perPage, GameBanRouteData);
         RoleBanPagination.Init(pageIndex, perPage, RoleBanRouteData);
 
-        var gameBans = SearchHelper.SearchServerBans(_banHelper.CreateServerBanJoin(), userId.ToString());
-        var roleBans = SearchHelper.SearchRoleBans(_banHelper.CreateRoleBanJoin(), userId.ToString());
+        var gameBans = SearchHelper.SearchServerBans(_banHelper.CreateServerBanJoin(), userId.ToString(), User);
+        var roleBans = SearchHelper.SearchRoleBans(_banHelper.CreateRoleBanJoin(), userId.ToString(), User);
 
         GameBanRouteData.Add("search", userId.ToString());
         GameBanRouteData.Add("show", "all");

--- a/SS14.Admin/Pages/RoleBans/Index.cshtml.cs
+++ b/SS14.Admin/Pages/RoleBans/Index.cshtml.cs
@@ -35,7 +35,7 @@ public class Index : PageModel
     {
         Pagination.Init(pageIndex, perPage, AllRouteData);
 
-        var bans = SearchHelper.SearchRoleBans(_banHelper.CreateRoleBanJoin(), search);
+        var bans = SearchHelper.SearchRoleBans(_banHelper.CreateRoleBanJoin(), search, User);
 
         bans = show switch
         {

--- a/SS14.Admin/Pages/Tables/BansTable.cshtml
+++ b/SS14.Admin/Pages/Tables/BansTable.cshtml
@@ -52,7 +52,7 @@
                     </a>
                     <br/>
                 }
-                @if (User.IsInRole("ADMIN"))
+                @if (User.IsInRole(Constants.PIIRole))
                 {
                     if (ban.Address != null)
                     {

--- a/SS14.Admin/Pages/Tables/ConnectionsTable.cshtml
+++ b/SS14.Admin/Pages/Tables/ConnectionsTable.cshtml
@@ -34,8 +34,16 @@
             </td>
             <td class="font-monospace">@log.UserId</td>
             <td>@log.Time.ToString("yyyy-MM-dd HH:mm:ss")</td>
-            <td class="font-monospace constrained-150">@log.Address</td>
-            <td class="font-monospace constrained-150">@(log.HWId is { } hwid ? Convert.ToBase64String(hwid) : null)</td>
+            @if (User.IsInRole(Constants.PIIRole))
+            {
+                <td class="font-monospace constrained-150">@log.Address</td>
+                <td class="font-monospace constrained-150">@(log.HWId is { } hwid ? Convert.ToBase64String(hwid) : null)</td>
+            }
+            else
+            {
+                <td class="font-monospace constrained-150">Hidden</td>
+                <td class="font-monospace constrained-150">Hidden</td>
+            }
             <td>
                 @switch (log.Denied)
                 {


### PR DESCRIPTION
Closes #66.

I hope I got all instances, this makes it so you're unable to see PII of any user, or search for it if you don't have the permission.

In the cases where I could remove it without affecting the layout of the page, I did. Where I couldn't, I replaced the text with "Hidden". I'm ready for this to be torn to shreds in a review, as I wouldn't be surprised if I made a silly mistake. 

The ban creation page was also updated to remove the buttons, and replace them with checkboxes instead

![image](https://github.com/space-wizards/SS14.Admin/assets/56081759/5e3a1f99-beda-4c71-a2d2-b4ce87805416)
![image](https://github.com/space-wizards/SS14.Admin/assets/56081759/b5ba7d39-331c-412a-a1b0-ad99cdac0720)
![image](https://github.com/space-wizards/SS14.Admin/assets/56081759/b6798564-163b-4302-b30b-4ccff8921b00)
