### PR TITLE
Logs csv export

### DIFF
--- a/SS14.Admin/AdminLogs/Export/ExportConfiguration.cs
+++ b/SS14.Admin/AdminLogs/Export/ExportConfiguration.cs
@@ -1,0 +1,16 @@
+﻿namespace SS14.Admin.AdminLogs.Export;
+
+public class ExportConfiguration
+{
+    public const string Name = "Export";
+
+    /// <summary>
+    /// The maximum amount of export processes that can be queued up before new export requests will be rejected
+    /// </summary>
+    public int ProcessQueueMaxSize { get; set; } = 6;
+
+    /// <summary>
+    /// This is the directory for containing generated exports
+    /// </summary>
+    public string ExportDirectory { get; set; } = "export";
+}

--- a/SS14.Admin/AdminLogs/Export/ExportProcessItem.cs
+++ b/SS14.Admin/AdminLogs/Export/ExportProcessItem.cs
@@ -1,0 +1,21 @@
+﻿namespace SS14.Admin.AdminLogs.Export;
+
+public sealed class ExportProcessItem
+{
+    public DateTime? FromDate { get; }
+    public DateTime? ToDate { get; }
+    public int? RoundId { get; }
+
+    public string? Search { get; }
+
+    public bool UseCompression { get; }
+
+    public ExportProcessItem(string? search = null, DateTime? fromDate = null, DateTime? toDate = null, int? roundId = null, bool useCompression = false)
+    {
+        Search = search;
+        FromDate = fromDate;
+        ToDate = toDate;
+        UseCompression = useCompression;
+        RoundId = roundId;
+    }
+}

--- a/SS14.Admin/AdminLogs/Export/LogExportBackgroundService.cs
+++ b/SS14.Admin/AdminLogs/Export/LogExportBackgroundService.cs
@@ -1,0 +1,42 @@
+﻿using Serilog;
+using ILogger = Serilog.ILogger;
+
+namespace SS14.Admin.AdminLogs.Export;
+
+public sealed class LogExportBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly LogExportQueue _queue;
+    private readonly ILogger _log;
+
+    public LogExportBackgroundService(IServiceProvider provider, LogExportQueue queue, IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+        _queue = queue;
+
+        _log = Log.ForContext<LogExportBackgroundService>();
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _log.Information("{ServiceName} started", nameof(LogExportBackgroundService));
+        return ProcessQueueAsync(stoppingToken);
+    }
+
+    private async Task ProcessQueueAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var item = await _queue.DequeueAsync(ct);
+            await ProcessTask(item, ct);
+        }
+    }
+
+    private async Task ProcessTask(ExportProcessItem item, CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var exporter =  scope.ServiceProvider.GetRequiredService<LogExporter>();
+        var filename = await exporter.Export(item, ct);
+        await _queue.ReportFinishedExport(filename);
+    }
+}

--- a/SS14.Admin/AdminLogs/Export/LogExportExtension.cs
+++ b/SS14.Admin/AdminLogs/Export/LogExportExtension.cs
@@ -1,0 +1,47 @@
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.Extensions.Options;
+
+namespace SS14.Admin.AdminLogs.Export;
+
+public static class LogExportExtension
+{
+    public static void MapLogExportEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/logs/export/poll",  async (CancellationToken ct, LogExportQueue queue) =>
+        {
+            var timoutCt = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timoutCt.CancelAfter(TimeSpan.FromSeconds(120));
+            using var channel = queue.CreateReportChannel();
+            var filename = await channel.Listen(timoutCt.Token);
+
+            return Results.Ok(filename);
+        }).RequireAuthorization();
+
+        endpoints.MapGet("/logs/export/list", async (IOptions<ExportConfiguration> config) =>
+        {
+            var exportPath = Path.Combine(Directory.GetCurrentDirectory(), config.Value.ExportDirectory);
+            var files = Directory.EnumerateFiles(exportPath, "*.csv*");
+
+            return Results.Ok(files.Select(Path.GetFileName));
+
+        }).RequireAuthorization();
+
+        endpoints.MapGet("/logs/export/download/{filename}", async (string filename, IOptions<ExportConfiguration> config) =>
+        {
+            var extension = Path.GetExtension(filename);
+            var mimetype = extension switch
+            {
+                ".gz" => "application/x-gzip",
+                ".csv" => "text/csv",
+                _ => null
+            };
+
+            if (mimetype == null)
+                return Results.NotFound();
+            var basePath = Path.Combine(Directory.GetCurrentDirectory(), config.Value.ExportDirectory);
+            var path = Path.Combine(basePath, filename);
+            return !File.Exists(path) ? Results.NotFound() : Results.File(path, contentType: mimetype);
+        }).RequireAuthorization();
+    }
+}

--- a/SS14.Admin/AdminLogs/Export/LogExportQueue.cs
+++ b/SS14.Admin/AdminLogs/Export/LogExportQueue.cs
@@ -1,0 +1,96 @@
+﻿using System.Threading.Channels;
+using Microsoft.Extensions.Options;
+
+namespace SS14.Admin.AdminLogs.Export;
+
+public sealed class LogExportQueue
+{
+    private readonly IOptions<ExportConfiguration> _configuration;
+    private readonly Channel<ExportProcessItem> _queue;
+
+    private readonly List<Channel<string>> _reportChannels = [];
+
+    public int MaxItemCount => _configuration.Value.ProcessQueueMaxSize;
+    public int Count => _queue.Reader.Count;
+
+    public LogExportQueue(IOptions<ExportConfiguration> configuration)
+    {
+        _configuration = configuration;
+
+        var channelConfiguration = new BoundedChannelOptions(MaxItemCount)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite
+        };
+
+        _queue = Channel.CreateBounded<ExportProcessItem>(channelConfiguration);
+    }
+
+    public async Task<bool> TryQueueProcessItem(ExportProcessItem item)
+    {
+        if (Count == MaxItemCount)
+            return false;
+
+        await _queue.Writer.WriteAsync(item);
+        return true;
+    }
+
+    public async ValueTask<ExportProcessItem> DequeueAsync(CancellationToken cancellationToken)
+    {
+        return await _queue.Reader.ReadAsync(cancellationToken);
+    }
+
+    public ReportChannel CreateReportChannel()
+    {
+        var channelOptions = new BoundedChannelOptions(1)
+        {
+            SingleReader = true,
+            SingleWriter = true,
+            AllowSynchronousContinuations = false,
+            FullMode = BoundedChannelFullMode.DropOldest,
+        };
+
+        var channel = Channel.CreateBounded<string>(channelOptions);
+        _reportChannels.Add(channel);
+
+        return new ReportChannel(
+            channel,
+            new WeakReference<IList<Channel<string>>>(_reportChannels)
+        );
+    }
+
+    public async Task ReportFinishedExport(string filename)
+    {
+        foreach (var channel in _reportChannels)
+        {
+            await channel.Writer.WriteAsync(filename);
+        }
+    }
+
+    public sealed record ReportChannel : IDisposable
+    {
+        private readonly Channel<string> _channel;
+        private readonly WeakReference<IList<Channel<string>>> _channels;
+
+        public ReportChannel(Channel<string> channel, WeakReference<IList<Channel<string>>> channels)
+        {
+            _channel = channel;
+            _channels = channels;
+        }
+
+
+        public async ValueTask<string> Listen(CancellationToken ct)
+        {
+            return await _channel.Reader.ReadAsync(ct);
+        }
+
+        public void Dispose()
+        {
+            _channel.Writer.TryComplete();
+
+            if (!_channels.TryGetTarget(out var channels))
+                return;
+
+            channels.Remove(_channel);
+        }
+    }
+}

--- a/SS14.Admin/AdminLogs/Export/LogExporter.cs
+++ b/SS14.Admin/AdminLogs/Export/LogExporter.cs
@@ -1,0 +1,107 @@
+﻿using System.IO.Compression;
+using Content.Server.Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace SS14.Admin.AdminLogs.Export;
+
+public sealed class LogExporter
+{
+    private const char ColumnSeparator = ',';
+    private const char RowSeparator = ';';
+    private const char Quote = '"';
+    private const string EscapedQuote = "\"\"";
+
+    private readonly PostgresServerDbContext _context;
+    private readonly IOptions<ExportConfiguration> _configuration;
+
+    public LogExporter(PostgresServerDbContext context, IOptions<ExportConfiguration> configuration)
+    {
+        _context = context;
+        _configuration = configuration;
+    }
+
+    public async Task<string> Export(ExportProcessItem item, CancellationToken ct)
+    {
+        // Prevent accidentally exporting all logs
+        if ((!item.FromDate.HasValue || !item.ToDate.HasValue) && !item.RoundId.HasValue)
+            throw new Exception("Neither date or round id filter is set correctly for log export.");
+
+        var filename = $"{DateTime.UtcNow.ToShortDateString()}-{Guid.NewGuid()}_log_export.csv{(item.UseCompression ? ".gz" : "")}";
+        var path = Path.Combine(_configuration.Value.ExportDirectory, filename);
+        await using var fileStream =  new FileStream(path, FileMode.Create, FileAccess.Write);
+
+        if (item.UseCompression)
+        {
+            await using var compressionStream = new GZipStream(fileStream, CompressionMode.Compress, leaveOpen: true);
+            await using var writer = new StreamWriter(compressionStream);
+            await WriteCsv(writer, item, ct);
+        }
+        else
+        {
+            await using var writer = new StreamWriter(fileStream);
+            await WriteCsv(writer, item, ct);
+        }
+
+        return filename;
+    }
+
+    private async Task WriteCsv(StreamWriter writer, ExportProcessItem item, CancellationToken ct)
+    {
+        var query = _context.AdminLog
+            .AsNoTracking()
+            .AsQueryable();
+
+        if (item.RoundId.HasValue)
+            query = query.Where(e => e.RoundId == item.RoundId);
+
+        if (item is { FromDate: not null, ToDate: not null })
+            query = query.Where(e => item.FromDate.Value.Date.ToUniversalTime() <= e.Date
+                                     && e.Date <= item.ToDate.Value.Date.ToUniversalTime());
+
+        if (item.Search != null)
+            query = query.Where(e => EF.Functions.ToTsVector("english", e.Message).Matches(item.Search));
+
+        await WriteCsvHeader(writer);
+
+        await foreach (var log in query.AsAsyncEnumerable().WithCancellation(ct))
+        {
+            await writer.WriteAsync(log.Id.ToString());
+            await writer.WriteAsync(ColumnSeparator);
+            await writer.WriteAsync(log.RoundId.ToString());
+            await writer.WriteAsync(ColumnSeparator);
+            await writer.WriteAsync(log.Date.ToString("O"));
+            await writer.WriteAsync(ColumnSeparator);
+            await writer.WriteAsync(log.Type.ToString());
+            await writer.WriteAsync(ColumnSeparator);
+            await writer.WriteAsync(Quote);
+            await writer.WriteAsync(log.Message.Replace(Quote.ToString(), EscapedQuote));
+            await writer.WriteAsync(Quote);
+            await writer.WriteAsync(ColumnSeparator);
+            await writer.WriteAsync(Quote);
+            await writer.WriteAsync(log.Json.RootElement.GetRawText().Replace(Quote.ToString(), EscapedQuote));
+            await writer.WriteAsync(Quote);
+            await writer.WriteAsync(ColumnSeparator);
+            await writer.WriteAsync(log.Impact.ToString());
+            await writer.WriteLineAsync(RowSeparator);
+        }
+    }
+
+    private async Task WriteCsvHeader(StreamWriter writer)
+    {
+        await writer.WriteAsync("id");
+        await writer.WriteAsync(ColumnSeparator);
+        await writer.WriteAsync("round_id");
+        await writer.WriteAsync(ColumnSeparator);
+        await writer.WriteAsync("timestamp");
+        await writer.WriteAsync(ColumnSeparator);
+        await writer.WriteAsync("type");
+        await writer.WriteAsync(ColumnSeparator);
+        await writer.WriteAsync("message");
+        await writer.WriteAsync(ColumnSeparator);
+        await writer.WriteAsync("json");
+        await writer.WriteAsync(ColumnSeparator);
+        await writer.WriteAsync("impact");
+        await writer.WriteLineAsync(RowSeparator);
+    }
+}

--- a/SS14.Admin/Pages/Logs/Export.cshtml
+++ b/SS14.Admin/Pages/Logs/Export.cshtml
@@ -1,0 +1,115 @@
+﻿@page
+@model SS14.Admin.Pages.Logs.Export
+
+@{
+    ViewData["Title"] = "Admin Logs";
+}
+
+<div class="container">
+    <form id="export-form" method="post">
+        <p>Export admin logs as CSV. A maximum of @Export.MaxDays days can be exported at once.</p>
+        <p>Check use round id to use the round id instead of the date</p>
+        <div class="form-group py-2 d-flex align-items-center gap-2">
+            <label asp-for="FromDate" class="sr-only">Date from:</label>
+            <input asp-for="FromDate" class="form-control flex-grow-1" id="from-date" placeholder="Date from" max="@(DateTime.Now.ToString("O"))"/>
+            <label asp-for="ToDate" class="sr-only">Date to:</label>
+            <input asp-for="ToDate" class="form-control flex-grow-1" id="to-date" placeholder="Date to" max="@(DateTime.Now.ToString("O"))"/>
+            @*<button id="date-clear" class="btn btn-sm"><i class="fas fa-times"></i></button>*@
+        </div>
+        <div class="form-group d-flex py-2">
+            <label asp-for="RoundId" class="sr-only">Round id</label>
+            <input type="number" id="round-id" asp-for="RoundId" placeholder="Round id" class="form-control flex-grow-1"/>
+        </div>
+        <div class="form-group d-flex py-2">
+            <label asp-for="SearchText" style="width: 120px">Search text</label>
+            <input asp-for="SearchText" type="text" class="form-control flex-grow-1 mx-2"/>
+        </div>
+        <div class="form-group d-flex align-items-center justify-content-end py-2">
+            <span id="validation-errors" class="mx-2 mb-0 text-danger d-block">@Model.ErrorMessage</span>
+            <label asp-for="UseRoundId" style="width: 95px">Use round id</label>
+            <input type="checkbox" id="use-round-id" asp-for="UseRoundId" class="mx-2">
+            <label asp-for="UseCompression" style="width: 220px">Export as compressed gzip file</label>
+            <input asp-for="UseCompression" class="mx-2" type="checkbox"/>
+            <input class="btn btn-primary" type="submit" value="Export">
+        </div>
+    </form>
+</div>
+
+<div class="container">
+<ul>
+@foreach (var filename in Model.ListExportedFiles())
+{
+    <li><a href="export/download/@filename">@filename</a></li>
+}
+@if (Model.Processing)
+{
+    <li>
+    <div id="spinner">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+    <a hidden id="download-link"></a>
+    </li>
+}
+</ul>
+</div>
+
+@section scripts {
+    <script>
+        $(document).ready(function() {
+            document.getElementById('export-form').addEventListener('submit', function(e) {
+                const errorOutput = document.querySelector('#validation-errors');
+                const roundIdField = document.querySelector("#round-id");
+                if (document.querySelector('#use-round-id').checked)
+                {
+                    if (roundIdField.value === '')
+                    {
+                        e.preventDefault();
+                        errorOutput.innerText = '@Export.RoundIdMissingError';
+                    }
+
+                    return;
+                }
+
+                const fromField = document.querySelector('#from-date');
+                const toField = document.querySelector('#to-date');
+                const from = DateTime.fromISO(fromField.value);
+                const to = DateTime.fromISO(toField.value);
+                const diff = to.diff(from, 'days');
+                if (diff.days < 0 || diff.days > @(Export.MaxDays))
+                {
+                    e.preventDefault()
+                    errorOutput.innerText = diff.days < 0 ? '@Export.FromAfterToError' : '@Export.DateRangeToLargeError';
+
+                    return;
+                }
+                errorOutput.innerText = '';
+            })
+        });
+    </script>
+    @if (Model.Processing)
+    {
+        <script>
+            $(document).ready(async function() {
+                let fetched = false;
+                let filename = "";
+                while (!fetched)
+                {
+                    const result = await fetch("export/poll")
+                    fetched = result.ok;
+                    filename = (await result.text()).replaceAll('"', '');
+                }
+                document.querySelector('#spinner').hidden = true;
+                const link = document.querySelector('#download-link');
+                link.hidden = false;
+                const url = "export/download/" + filename;
+
+                link.href = url;
+                link.innerText = filename;
+            })
+        </script>
+    }
+
+}
+

--- a/SS14.Admin/Pages/Logs/Export.cshtml.cs
+++ b/SS14.Admin/Pages/Logs/Export.cshtml.cs
@@ -1,0 +1,83 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
+using SS14.Admin.AdminLogs.Export;
+
+namespace SS14.Admin.Pages.Logs;
+
+public class Export : PageModel
+{
+    public const int MaxDays = 4;
+    public const string FromAfterToError = "From date needs to be before to date";
+    public const string DateRangeToLargeError = "Selected date range larger than 7 days";
+    public const string RoundIdMissingError = "Round id is required";
+
+    private readonly LogExportQueue _queue;
+    private readonly IOptions<ExportConfiguration> _config;
+
+    [BindProperty, DisplayFormat(DataFormatString = "{0:yyyy-MM-ddTHH:mm}", ApplyFormatInEditMode = true)]
+    public DateTime FromDate { get; set; } = DateTime.Now.AddDays(-1);
+
+    [BindProperty, DisplayFormat(DataFormatString = "{0:yyyy-MM-ddTHH:mm}", ApplyFormatInEditMode = true)]
+    public DateTime ToDate { get; set; } = DateTime.Now;
+
+    [BindProperty]
+    public bool UseRoundId { get; set; }
+
+    [BindProperty]
+    public int? RoundId { get; set; }
+
+    [BindProperty]
+    public string? SearchText { get; set; }
+
+    [BindProperty]
+    public bool UseCompression { get; set; } = true;
+
+    public string? ErrorMessage { get; set; }
+
+    public bool Processing { get; set; }
+
+    public Export(LogExportQueue queue, IOptions<ExportConfiguration> config)
+    {
+        _queue = queue;
+        _config = config;
+    }
+
+    public void OnGet()
+    {
+
+    }
+
+    public async Task OnPost(CancellationToken ct)
+    {
+        switch (UseRoundId)
+        {
+            case false when FromDate > ToDate:
+                ErrorMessage = FromAfterToError;
+                return;
+            case false when (ToDate - FromDate).TotalDays > MaxDays:
+                ErrorMessage = DateRangeToLargeError;
+                return;
+            case true when !RoundId.HasValue:
+                ErrorMessage = RoundIdMissingError;
+                break;
+        }
+
+        DateTime? from = !UseRoundId ? FromDate : null;
+        DateTime? to = !UseRoundId ? ToDate : null;
+        var roundId = UseRoundId ? RoundId : null;
+
+        var item = new ExportProcessItem(SearchText, from, to, roundId, UseCompression);
+        await _queue.TryQueueProcessItem(item);
+        Processing = true;
+    }
+
+    public List<string?> ListExportedFiles()
+    {
+        var exportPath = Path.Combine(Directory.GetCurrentDirectory(), _config.Value.ExportDirectory);
+        var files = Directory.EnumerateFiles(exportPath, "*.csv*");
+
+        return files.Select(Path.GetFileName).ToList();
+    }
+}

--- a/SS14.Admin/Pages/Shared/_Layout.cshtml
+++ b/SS14.Admin/Pages/Shared/_Layout.cshtml
@@ -68,6 +68,9 @@
                         <a class="nav-link" asp-area="" asp-page="/Logs/Index">Logs</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" asp-area="" asp-page="/Logs/Export">Export Logs</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" asp-area="" asp-page="/Characters/Index">Characters</a>
                     </li>
                     <li class="nav-item">

--- a/SS14.Admin/Startup.cs
+++ b/SS14.Admin/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Serilog;
+using SS14.Admin.AdminLogs.Export;
 using SS14.Admin.Helpers;
 using SS14.Admin.SignIn;
 
@@ -26,7 +27,11 @@ namespace SS14.Admin
             services.AddScoped<LoginHandler>();
             services.AddScoped<BanHelper>();
             services.AddScoped<PlayerLocator>();
+            services.AddScoped<LogExporter>();
+            services.AddSingleton<LogExportQueue>();
             services.AddHttpContextAccessor();
+
+            services.AddHostedService<LogExportBackgroundService>();
 
             var connStr = Configuration.GetConnectionString("DefaultConnection");
             if (connStr == null)
@@ -124,6 +129,7 @@ namespace SS14.Admin
             {
                 endpoints.MapRazorPages();
                 endpoints.MapControllers();
+                endpoints.MapLogExportEndpoints();
             });
         }
     }


### PR DESCRIPTION
This PR implements exporting admin logs as either a csv file or a gzip compressed csv file.
Files are exported using  a hosted service and stored inside a configurable directory.
Old exports will need to be deleted using something like a systemd timer or a cronjob